### PR TITLE
Various improvements and fixes

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 				TargetAttributes = {
 					8E3CCDA01C23DDE500A859FB = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -266,6 +267,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.morenotepad.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -278,6 +280,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.morenotepad.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		8E3CCDAA1C23DDE600A859FB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8E3CCDA81C23DDE600A859FB /* Main.storyboard */; };
 		8E3CCDAC1C23DDE600A859FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E3CCDAB1C23DDE600A859FB /* Assets.xcassets */; };
 		8E3CCDAF1C23DDE600A859FB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8E3CCDAD1C23DDE600A859FB /* LaunchScreen.storyboard */; };
-		8E3CCDB81C23DEE000A859FB /* UITextField+Histroy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3CCDB71C23DEE000A859FB /* UITextField+Histroy.swift */; };
+		8E3CCDB81C23DEE000A859FB /* UITextField+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3CCDB71C23DEE000A859FB /* UITextField+History.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,7 +23,7 @@
 		8E3CCDAB1C23DDE600A859FB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8E3CCDAE1C23DDE600A859FB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8E3CCDB01C23DDE600A859FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8E3CCDB71C23DEE000A859FB /* UITextField+Histroy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Histroy.swift"; sourceTree = "<group>"; };
+		8E3CCDB71C23DEE000A859FB /* UITextField+History.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+History.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +70,7 @@
 		8E3CCDB61C23DEB500A859FB /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				8E3CCDB71C23DEE000A859FB /* UITextField+Histroy.swift */,
+				8E3CCDB71C23DEE000A859FB /* UITextField+History.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -149,7 +149,7 @@
 			files = (
 				8E3CCDA71C23DDE600A859FB /* ViewController.swift in Sources */,
 				8E3CCDA51C23DDE600A859FB /* AppDelegate.swift in Sources */,
-				8E3CCDB81C23DEE000A859FB /* UITextField+Histroy.swift in Sources */,
+				8E3CCDB81C23DEE000A859FB /* UITextField+History.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="qyF-TI-VV0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11198.2" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="qyF-TI-VV0">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,16 +15,16 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xU5-XP-Uf3">
-                                <rect key="frame" x="46" y="81" width="228" height="30"/>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xU5-XP-Uf3">
+                                <frame key="frameInset" minX="46" minY="81" width="228" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="xU5-XP-Uf3" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="17" id="EKX-vV-0A8"/>
                             <constraint firstItem="xU5-XP-Uf3" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="30" id="Jai-6O-sbx"/>
@@ -33,8 +34,8 @@
                     <navigationItem key="navigationItem" id="ADm-eq-3kZ">
                         <nil key="title"/>
                         <textField key="titleView" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" id="UCv-46-Vv2">
-                            <rect key="frame" x="96" y="7" width="128" height="30"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <rect key="frame" x="123.5" y="7" width="128" height="30"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
                         </textField>
@@ -62,16 +63,16 @@
                         <viewControllerLayoutGuide type="bottom" id="bR5-5v-PYL"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="BC1-ln-GE2">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gjd-mz-CNO">
-                                <rect key="frame" x="66" y="81" width="188" height="30"/>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gjd-mz-CNO">
+                                <frame key="frameInset" minX="66" minY="81" width="188" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="gjd-mz-CNO" firstAttribute="leading" secondItem="BC1-ln-GE2" secondAttribute="leadingMargin" constant="50" id="JVd-Ch-dgW"/>
                             <constraint firstAttribute="trailingMargin" secondItem="gjd-mz-CNO" secondAttribute="trailing" constant="50" id="Mny-vu-Oq5"/>
@@ -91,7 +92,6 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="qyF-TI-VV0" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="qRx-xo-ii6">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -50,7 +50,7 @@ extension ViewController:UITextFieldDelegate {
         }
     }
     
-    func textField(textField: UITextField, selectHistroy history:String) {
+    func textField(textField: UITextField, selectHistory history:String) {
         let alert = UIAlertView(title: "Hello", message: history, delegate: nil, cancelButtonTitle: "OK")
         
         alert.show()

--- a/Source/UITextField+History.swift
+++ b/Source/UITextField+History.swift
@@ -1,5 +1,5 @@
 //
-//  UITextField+Histroy.swift
+//  UITextField+History.swift
 //  Example
 //
 //  Created by zhangxiuming on 15/12/18.
@@ -10,14 +10,14 @@ import Foundation
 import UIKit
 
 //extension UITextFieldDelegate {
-//    func textField(textField: UITextField, selectHistroy history:String) {
+//    func textField(textField: UITextField, selectHistory history:String) {
 //    }
 //}
 
 public extension UITextField {
     var showHistoryBeginEdit:Bool {
         get {
-            if let yes = objc_getAssociatedObject(self, &AssociatedKeys.showHistoryBeginEditKey) {
+            if let yes = objc_getAssociatedObject(self, &AssociatedKeys.ShowHistoryBeginEditKey) {
                 return (yes as! NSNumber).boolValue
             }
             
@@ -25,13 +25,13 @@ public extension UITextField {
         }
         
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.showHistoryBeginEditKey, NSNumber(bool: newValue), .OBJC_ASSOCIATION_RETAIN)
+            objc_setAssociatedObject(self, &AssociatedKeys.ShowHistoryBeginEditKey, NSNumber(bool: newValue), .OBJC_ASSOCIATION_RETAIN)
         }
     }
     
     var dismissHistoryEndEdit:Bool {
         get {
-            if let yes = objc_getAssociatedObject(self, &AssociatedKeys.dismissHistoryEndEditKey) {
+            if let yes = objc_getAssociatedObject(self, &AssociatedKeys.DismissHistoryEndEditKey) {
                 return (yes as! NSNumber).boolValue
             }
             
@@ -39,7 +39,7 @@ public extension UITextField {
         }
         
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.dismissHistoryEndEditKey, NSNumber(bool: newValue), .OBJC_ASSOCIATION_RETAIN)
+            objc_setAssociatedObject(self, &AssociatedKeys.DismissHistoryEndEditKey, NSNumber(bool: newValue), .OBJC_ASSOCIATION_RETAIN)
         }
     }
 
@@ -59,7 +59,7 @@ public extension UITextField {
     
     var clearButtonTitle:String! {
         get {
-            if let title = objc_getAssociatedObject(self, &AssociatedKeys.clearButtonTitleKey) {
+            if let title = objc_getAssociatedObject(self, &AssociatedKeys.ClearButtonTitleKey) {
                 return title as! String
             }
             
@@ -67,7 +67,7 @@ public extension UITextField {
         }
         
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.clearButtonTitleKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+            objc_setAssociatedObject(self, &AssociatedKeys.ClearButtonTitleKey, newValue, .OBJC_ASSOCIATION_RETAIN)
         }
     }
     
@@ -190,7 +190,7 @@ public extension UITextField {
         if self.historyIsVisible {
             self.dismissHistoryView()
         } else {
-            if self.filterHistroy != nil && self.filterHistroy.count > 0 {
+            if self.filterHistory != nil && self.filterHistory.count > 0 {
                 self.showHistoryView()
             }
         }
@@ -199,7 +199,7 @@ public extension UITextField {
     func beginEditingNotification(aNoti:NSNotification) {
         if aNoti.object === self {
             if self.historys.count == 0 { return }
-            self.filterHistroy = self.historys
+            self.filterHistory = self.historys
             
             if self.showHistoryBeginEdit {
                 self.showHistoryView()
@@ -219,8 +219,8 @@ public extension UITextField {
         if aNoti.object === self {
             if let t = self.text where !t.isEmpty {
                 let predicate = NSPredicate(format: "SELF CONTAINS[cd] %@", t)
-                self.filterHistroy = self.historys.filteredArrayUsingPredicate(predicate)
-                if self.filterHistroy.count == 0 {
+                self.filterHistory = self.historys.filteredArrayUsingPredicate(predicate)
+                if self.filterHistory.count == 0 {
                     if self.historyIsVisible {
                         self.dismissHistoryView()
                     }
@@ -229,7 +229,7 @@ public extension UITextField {
                     self.showHistoryView()
                 }
             } else {
-                self.filterHistroy = self.historys
+                self.filterHistory = self.historys
                 if !self.historyIsVisible {
                     self.showHistoryView()
                 }
@@ -251,26 +251,26 @@ public extension UITextField {
 
 public extension UITextField {
     private struct AssociatedKeys {
-        static var HistoryKey               = "UITextField+historyKey"
-        static var HistoryIsVisibleKey      = "UITextField+HistoryIsVisibleKey"
+        static var HistoryKey               = "UITextField+History+HistoryKey"
+        static var HistoryIsVisibleKey      = "UITextField+History+HistoryIsVisibleKey"
         static var IdentifyKey              = "UITextField+History+Identify"
         static var TableViewKey             = "UITextField+History+TableView"
         static var ItemCellHeightKey        = "UITextField+History+ItemCellHeight"
         static var MaximumItemKey           = "UITextField+History+MaximumItem"
         static var MaximumSavedEntriesKey   = "UITextField+History+MaximumSavedEntries"
-        static var filterArrayKey           = "UITextField+History+filterArray"
-        static var clearButtonTitleKey      = "UITextField+History+clearButtonTitle"
-        static var showHistoryBeginEditKey  = "UITextField+History+showHistoryBeginEdit"
-        static var dismissHistoryEndEditKey = "UITextField+History+dismissHistoryEndEdit"
+        static var FilterArrayKey           = "UITextField+History+FilterArray"
+        static var ClearButtonTitleKey      = "UITextField+History+ClearButtonTitle"
+        static var ShowHistoryBeginEditKey  = "UITextField+History+ShowHistoryBeginEdit"
+        static var DismissHistoryEndEditKey = "UITextField+History+DismissHistoryEndEdit"
     }
     
-    private var filterHistroy:NSArray! {
+    private var filterHistory:NSArray! {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.filterArrayKey) as? NSArray
+            return objc_getAssociatedObject(self, &AssociatedKeys.FilterArrayKey) as? NSArray
         }
         
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.filterArrayKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKeys.FilterArrayKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
     
@@ -328,7 +328,7 @@ public extension UITextField {
     
     func clearAllHistory() {
         self.historys.removeAllObjects()
-        self.filterHistroy = self.historys
+        self.filterHistory = self.historys
         self.synchronize()
         
         self.tableView.removeFromSuperview()
@@ -338,9 +338,9 @@ public extension UITextField {
 
 extension UITextField:UITableViewDelegate, UITableViewDataSource {
     public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if let _ = self.filterHistroy { } else { self.filterHistroy = self.historys }
+        if let _ = self.filterHistory { } else { self.filterHistory = self.historys }
         
-        return self.filterHistroy.count
+        return self.filterHistory.count
     }
     
     public func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -354,7 +354,7 @@ extension UITextField:UITableViewDelegate, UITableViewDataSource {
             cell?.selectionStyle = .None
         }
         
-        cell?.textLabel?.text = self.filterHistroy.objectAtIndex(indexPath.row) as? String
+        cell?.textLabel?.text = self.filterHistory.objectAtIndex(indexPath.row) as? String
         
         return cell!
     }
@@ -383,8 +383,8 @@ extension UITextField:UITableViewDelegate, UITableViewDataSource {
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let history = self.historys[indexPath.row] as! String
         
-        if let dlg = self.delegate where dlg.respondsToSelector("textField:selectHistroy:") {
-            dlg.performSelector("textField:selectHistroy:", withObject: self, withObject: history)
+        if let dlg = self.delegate where dlg.respondsToSelector("textField:selectHistory:") {
+            dlg.performSelector("textField:selectHistory:", withObject: self, withObject: history)
         }
         
         self.tableView.removeFromSuperview()

--- a/Source/UITextField+History.swift
+++ b/Source/UITextField+History.swift
@@ -385,7 +385,7 @@ extension UITextField:UITableViewDelegate, UITableViewDataSource {
     }
     
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let history = self.historys[indexPath.row] as! String
+        let history = self.filterHistory[indexPath.row] as! String
         
         if let dlg = self.delegate where dlg.respondsToSelector("textField:selectHistory:") {
             dlg.performSelector("textField:selectHistory:", withObject: self, withObject: history)

--- a/Source/UITextField+History.swift
+++ b/Source/UITextField+History.swift
@@ -14,7 +14,26 @@ import UIKit
 //    }
 //}
 
+@objc public protocol UITextFieldHistoryDelegate: class {
+    optional func textField(textField: UITextField, selectHistory history:String)
+}
+
 public extension UITextField {
+    weak var historyDelegate:UITextFieldHistoryDelegate?
+        {
+        get {
+            if let h = objc_getAssociatedObject(self, &AssociatedKeys.HistoryDelegateKey) {
+                return (h as! UITextFieldHistoryDelegate)
+            }
+
+            return nil
+        }
+
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.HistoryDelegateKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
     var showHistoryBeginEdit:Bool {
         get {
             if let yes = objc_getAssociatedObject(self, &AssociatedKeys.ShowHistoryBeginEditKey) {
@@ -253,6 +272,7 @@ public extension UITextField {
 
 public extension UITextField {
     private struct AssociatedKeys {
+        static var HistoryDelegateKey       = "UITextField+History+HistoryDelegateKey"
         static var HistoryKey               = "UITextField+History+HistoryKey"
         static var HistoryIsVisibleKey      = "UITextField+History+HistoryIsVisibleKey"
         static var IdentifyKey              = "UITextField+History+Identify"
@@ -386,7 +406,8 @@ extension UITextField:UITableViewDelegate, UITableViewDataSource {
     
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let history = self.filterHistory[indexPath.row] as! String
-        
+
+        self.historyDelegate?.textField!(self,selectHistory: history)
         if let dlg = self.delegate where dlg.respondsToSelector("textField:selectHistory:") {
             dlg.performSelector("textField:selectHistory:", withObject: self, withObject: history)
         }

--- a/Source/UITextField+Histroy.swift
+++ b/Source/UITextField+Histroy.swift
@@ -141,9 +141,9 @@ extension UITextField {
     }
 
     private func addNotification() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "beginEditingNotification:", name: UITextFieldTextDidBeginEditingNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "endEditingNotification:", name: UITextFieldTextDidEndEditingNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "textDidChangeNotification:", name: UITextFieldTextDidChangeNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.beginEditingNotification(_:)), name: UITextFieldTextDidBeginEditingNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.endEditingNotification(_:)), name: UITextFieldTextDidEndEditingNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.textDidChangeNotification(_:)), name: UITextFieldTextDidChangeNotification, object: nil)
     }
     
     private func removeNotification() {
@@ -296,7 +296,7 @@ extension UITextField:UITableViewDelegate, UITableViewDataSource {
         
         let footer = UIButton(type: .RoundedRect)
         footer.setTitle(self.clearButtonTitle, forState: .Normal)
-        footer.addTarget(self, action: "clearAllHistory", forControlEvents: .TouchUpInside)
+        footer.addTarget(self, action: #selector(UITextField.clearAllHistory), forControlEvents: .TouchUpInside)
         
         return footer
     }

--- a/Source/UITextField+Histroy.swift
+++ b/Source/UITextField+Histroy.swift
@@ -116,6 +116,9 @@ public extension UITextField {
         
         window??.addSubview(self.tableView)
         self.tableView.reloadData()
+
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(UITextField.handleTextFieldTap(_:)))
+        self.addGestureRecognizer(tapRecognizer)
     }
 
     var tableView:UITableView! {
@@ -161,9 +164,6 @@ public extension UITextField {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.endEditingNotification(_:)), name: UITextFieldTextDidEndEditingNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.textDidChangeNotification(_:)), name: UITextFieldTextDidChangeNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.orientationdidChangeNotification(_:)), name: UIDeviceOrientationDidChangeNotification, object: nil)
-
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(UITextField.handleTextFieldTap(_:)))
-        self.addGestureRecognizer(tapRecognizer)
     }
     
     private func removeNotification() {
@@ -176,7 +176,9 @@ public extension UITextField {
         if self.historyIsVisible {
             self.dismissHistoryView()
         } else {
-            self.showHistoryView()
+            if self.filterHistroy != nil && self.filterHistroy.count > 0 {
+                self.showHistoryView()
+            }
         }
     }
 
@@ -204,8 +206,19 @@ public extension UITextField {
             if let t = self.text where !t.isEmpty {
                 let predicate = NSPredicate(format: "SELF CONTAINS[cd] %@", t)
                 self.filterHistroy = self.historys.filteredArrayUsingPredicate(predicate)
+                if self.filterHistroy.count == 0 {
+                    if self.historyIsVisible {
+                        self.dismissHistoryView()
+                    }
+                }
+                else {
+                    self.showHistoryView()
+                }
             } else {
                 self.filterHistroy = self.historys
+                if !self.historyIsVisible {
+                    self.showHistoryView()
+                }
             }
 
             self.tableView.reloadData()

--- a/Source/UITextField+Histroy.swift
+++ b/Source/UITextField+Histroy.swift
@@ -99,6 +99,20 @@ public extension UITextField {
         }
     }
 
+    var maximumSavedEntries:NSInteger {
+        get {
+            if let h = objc_getAssociatedObject(self, &AssociatedKeys.MaximumSavedEntriesKey) {
+                return (h as! NSNumber).integerValue
+            }
+
+            return 100
+        }
+
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.MaximumSavedEntriesKey, NSNumber(integer: newValue), .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
     func dismissHistoryView() {
         self.historyIsVisible = false;
         self.tableView.removeFromSuperview()
@@ -237,14 +251,15 @@ public extension UITextField {
 
 public extension UITextField {
     private struct AssociatedKeys {
-        static var HistoryKey            = "UITextField+historyKey"
-        static var HistoryIsVisibleKey   = "UITextField+HistoryIsVisibleKey"
-        static var IdentifyKey           = "UITextField+History+Identify"
-        static var TableViewKey          = "UITextField+History+TableView"
-        static var ItemCellHeightKey     = "UITextField+History+ItemCellHeight"
-        static var MaximumItemKey        = "UITextField+History+MaximumItem"
-        static var filterArrayKey        = "UITextField+History+filterArray"
-        static var clearButtonTitleKey   = "UITextField+History+clearButtonTitle"
+        static var HistoryKey               = "UITextField+historyKey"
+        static var HistoryIsVisibleKey      = "UITextField+HistoryIsVisibleKey"
+        static var IdentifyKey              = "UITextField+History+Identify"
+        static var TableViewKey             = "UITextField+History+TableView"
+        static var ItemCellHeightKey        = "UITextField+History+ItemCellHeight"
+        static var MaximumItemKey           = "UITextField+History+MaximumItem"
+        static var MaximumSavedEntriesKey   = "UITextField+History+MaximumSavedEntries"
+        static var filterArrayKey           = "UITextField+History+filterArray"
+        static var clearButtonTitleKey      = "UITextField+History+clearButtonTitle"
         static var showHistoryBeginEditKey  = "UITextField+History+showHistoryBeginEdit"
         static var dismissHistoryEndEditKey = "UITextField+History+dismissHistoryEndEdit"
     }
@@ -303,6 +318,11 @@ public extension UITextField {
         }
         
         historys.insertObject(value, atIndex: 0)
+
+        if historys.count > self.maximumSavedEntries {
+            historys.removeLastObject()
+        }
+
         self.synchronize()
     }
     

--- a/Source/UITextField+Histroy.swift
+++ b/Source/UITextField+Histroy.swift
@@ -160,6 +160,7 @@ public extension UITextField {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.beginEditingNotification(_:)), name: UITextFieldTextDidBeginEditingNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.endEditingNotification(_:)), name: UITextFieldTextDidEndEditingNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.textDidChangeNotification(_:)), name: UITextFieldTextDidChangeNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UITextField.orientationdidChangeNotification(_:)), name: UIDeviceOrientationDidChangeNotification, object: nil)
 
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(UITextField.handleTextFieldTap(_:)))
         self.addGestureRecognizer(tapRecognizer)
@@ -208,6 +209,15 @@ public extension UITextField {
             }
 
             self.tableView.reloadData()
+        }
+    }
+
+    func orientationdidChangeNotification(aNoti:NSNotification) {
+        if self.historyIsVisible {
+            let dispatchTime: dispatch_time_t = dispatch_time(DISPATCH_TIME_NOW, Int64(0.2 * Double(NSEC_PER_SEC)))
+            dispatch_after(dispatchTime, dispatch_get_main_queue(), {
+                self.showHistoryView()
+            })
         }
     }
 }

--- a/Source/UITextField+Histroy.swift
+++ b/Source/UITextField+Histroy.swift
@@ -14,7 +14,7 @@ import UIKit
 //    }
 //}
 
-extension UITextField {
+public extension UITextField {
     var showHistoryBeginEdit:Bool {
         get {
             if let yes = objc_getAssociatedObject(self, &AssociatedKeys.showHistoryBeginEditKey) {
@@ -212,7 +212,7 @@ extension UITextField {
     }
 }
 
-extension UITextField {
+public extension UITextField {
     private struct AssociatedKeys {
         static var HistoryKey            = "UITextField+historyKey"
         static var HistoryIsVisibleKey   = "UITextField+HistoryIsVisibleKey"


### PR DESCRIPTION
This pull request is providing the following fixes/improvements : 
- Updated code to Swift2.3
- Fix issue where wrong item was returned in textField:selectHistory: delegate if values were filtered
- Make some extensions public to allow to call this code from objective-c code
- Fix issues with history table position and size when rotating the device
- Hide the history table if there is nothing to show (when filtered results become empty)
- Hide/unhide history table by tapping on the text field
- Added a maximum number of saved entries to prevent from having too much data saved in NSUserDefaults. If limit set to 0, the limitation is not active (previous behaviour)
- Add alternate delegate method to be able to enable history table on UITextField in complex classes (like in UISearchBar)